### PR TITLE
Add Google Analytics

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@mdx-js/loader": "^3.1.0",
         "@mdx-js/react": "^3.1.0",
         "@next/mdx": "^15.3.3",
+        "@next/third-parties": "^15.3.3",
         "@tailwindcss/typography": "^0.5.16",
         "@tanstack/react-query": "^5.64.2",
         "next": "15.3.3",
@@ -3341,6 +3342,19 @@
       ],
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/@next/third-parties": {
+      "version": "15.3.3",
+      "resolved": "https://registry.npmjs.org/@next/third-parties/-/third-parties-15.3.3.tgz",
+      "integrity": "sha512-kwhDkK/3klTvW6SuNkmIMSqzEk9Rnc7PkpGeAi3x0mcbPJhFTwdC/qTEd/HZt53J2yFv73YohOBk6dUG3TEIkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "third-party-capital": "1.0.20"
+      },
+      "peerDependencies": {
+        "next": "^13.0.0 || ^14.0.0 || ^15.0.0",
+        "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -14803,6 +14817,12 @@
       "dependencies": {
         "b4a": "^1.6.4"
       }
+    },
+    "node_modules/third-party-capital": {
+      "version": "1.0.20",
+      "resolved": "https://registry.npmjs.org/third-party-capital/-/third-party-capital-1.0.20.tgz",
+      "integrity": "sha512-oB7yIimd8SuGptespDAZnNkzIz+NWaJCu2RMsbs4Wmp9zSDUM8Nhi3s2OOcqYuv3mN4hitXc8DVx+LyUmbUDiA==",
+      "license": "ISC"
     },
     "node_modules/tinybench": {
       "version": "2.9.0",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@mdx-js/loader": "^3.1.0",
     "@mdx-js/react": "^3.1.0",
     "@next/mdx": "^15.3.3",
+    "@next/third-parties": "^15.3.3",
     "@tailwindcss/typography": "^0.5.16",
     "@tanstack/react-query": "^5.64.2",
     "next": "15.3.3",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from 'next'
+import { GoogleAnalytics } from '@next/third-parties/google'
 import './globals.css'
 import { ReactNode } from 'react'
 import { textFont } from './fonts'
@@ -19,6 +20,7 @@ export default function RootLayout({ children }: Readonly<{
     {children}
     <Footer/>
     </body>
+    <GoogleAnalytics gaId="G-22NQZFFMH7" />
     </html>
   )
 }


### PR DESCRIPTION
Use [Next.js's addon](https://nextjs.org/docs/app/guides/third-party-libraries#google-analytics) to enable Google Analytics. Do it after page hydration to avoid any performance impact.