### PR TITLE
Switch schema validator to avoid eval

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -49,8 +49,7 @@
         "typescript-eslint": "^8.39.1",
         "vite": "^8.0.0",
         "vitest": "^4.0.0",
-        "wrangler": "^4.85.0",
-        "zod": "^4.1.12"
+        "wrangler": "^4.85.0"
       }
     },
     "node_modules/@alloc/quick-lru": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,10 @@
       "dependencies": {
         "@cucumber/messages": "^32.2.0",
         "@cucumber/react-components": "^24.1.2",
+        "@hyperjump/browser": "^1.3.1",
+        "@hyperjump/json-schema": "^1.17.6",
         "@sentry/react": "^10.30.0",
         "@tanstack/react-query": "^5.85.6",
-        "ajv": "^8.18.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-error-boundary": "^6.0.0",
@@ -1840,6 +1841,105 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
+    "node_modules/@hyperjump/browser": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@hyperjump/browser/-/browser-1.3.1.tgz",
+      "integrity": "sha512-Le5XZUjnVqVjkgLYv6yyWgALat/0HpB1XaCPuCZ+GCFki9NvXloSZITIJ0H+wRW7mb9At1SxvohKBbNQbrr/cw==",
+      "license": "MIT",
+      "dependencies": {
+        "@hyperjump/json-pointer": "^1.1.0",
+        "@hyperjump/uri": "^1.2.0",
+        "content-type": "^1.0.5",
+        "just-curry-it": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/jdesrosiers"
+      }
+    },
+    "node_modules/@hyperjump/json-pointer": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@hyperjump/json-pointer/-/json-pointer-1.1.2.tgz",
+      "integrity": "sha512-zPNgu1zdhtjQHFNLGzvEsLDsLOEvhRj6u6ktIQmlz7YPESv5uF8SnAe3Dq0oL6gZ6OGWSLq2n7pphRNF6Hpg6w==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/jdesrosiers"
+      }
+    },
+    "node_modules/@hyperjump/json-schema": {
+      "version": "1.17.6",
+      "resolved": "https://registry.npmjs.org/@hyperjump/json-schema/-/json-schema-1.17.6.tgz",
+      "integrity": "sha512-m0QggWCn58IACqLi3fqI9cuUrFju79DVAxjkDENo+xgE26963rudPMwKwwlkZkB+JqAgu+OGvJAMfE1toevfGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@hyperjump/json-pointer": "^1.1.0",
+        "@hyperjump/json-schema-formats": "^1.0.0",
+        "@hyperjump/pact": "^1.2.0",
+        "@hyperjump/uri": "^1.2.0",
+        "content-type": "^1.0.4",
+        "json-stringify-deterministic": "^1.0.12",
+        "just-curry-it": "^5.3.0",
+        "uuid": "^14.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/jdesrosiers"
+      },
+      "peerDependencies": {
+        "@hyperjump/browser": "^1.1.0"
+      }
+    },
+    "node_modules/@hyperjump/json-schema-formats": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@hyperjump/json-schema-formats/-/json-schema-formats-1.0.1.tgz",
+      "integrity": "sha512-qvcIxysnMfcPxyPSFFzzo28o2BN1CNT5b0tQXNUP0kaFpvptQNDg8SCLvlnMg2sYxuiuqna8+azGBaBthiskAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@hyperjump/uri": "^1.3.2",
+        "idn-hostname": "^15.1.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/hyperjump-io"
+      }
+    },
+    "node_modules/@hyperjump/json-schema/node_modules/uuid": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
+      }
+    },
+    "node_modules/@hyperjump/pact": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@hyperjump/pact/-/pact-1.4.0.tgz",
+      "integrity": "sha512-01Q7VY6BcAkp9W31Fv+ciiZycxZHGlR2N6ba9BifgyclHYHdbaZgITo0U6QMhYRlem4k8pf8J31/tApxvqAz8A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/jdesrosiers"
+      }
+    },
+    "node_modules/@hyperjump/uri": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@hyperjump/uri/-/uri-1.3.3.tgz",
+      "integrity": "sha512-rUqeUdL2aW7lzvSnCL6yUetXYzqxhsBEw9Z7Y1bEhgiRzcfO3kjY0UdD6c4H/bzxe0fXIjYuocjWQzinio8JTQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/jdesrosiers"
+      }
+    },
     "node_modules/@img/colour": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
@@ -2969,9 +3069,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2989,9 +3086,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3009,9 +3103,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3029,9 +3120,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3049,9 +3137,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3069,9 +3154,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4633,22 +4715,6 @@
         "node": ">= 14"
       }
     },
-    "node_modules/ajv": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
-      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
@@ -5209,6 +5275,15 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
@@ -5865,6 +5940,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-fifo": {
@@ -5887,22 +5963,6 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fastify"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/fastify"
-        }
-      ],
-      "license": "BSD-3-Clause"
     },
     "node_modules/fastq": {
       "version": "1.19.1",
@@ -6462,6 +6522,15 @@
         "node": ">= 14"
       }
     },
+    "node_modules/idn-hostname": {
+      "version": "15.1.8",
+      "resolved": "https://registry.npmjs.org/idn-hostname/-/idn-hostname-15.1.8.tgz",
+      "integrity": "sha512-MmLwddtSVyMtzYxx+xs2IFEbfyg/facubL/mEaAoJX/XIfjt1ly5QhPByihf4yrxZYbkQfRZVEnBgISv/e2ZWw==",
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      }
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -6819,17 +6888,26 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "license": "MIT"
-    },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stringify-deterministic": {
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/json-stringify-deterministic/-/json-stringify-deterministic-1.0.13.tgz",
+      "integrity": "sha512-Gm2hkhXlhD69QplkQGmY30S8Ps5noSFzruJKbgmD/nkYIXimS/Q0P1YIbJkWe2nbWDIzERmtp+hWGzC3Vk3bZg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/just-curry-it": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/just-curry-it/-/just-curry-it-5.3.0.tgz",
+      "integrity": "sha512-silMIRiFjUWlfaDhkgSzpuAyQ6EX/o09Eu8ZBfmFwQMbax7+LQzeIU2CBrICT6Ne4l86ITCGvUCBpCubWYy0Yw==",
       "license": "MIT"
     },
     "node_modules/keyv": {
@@ -8163,7 +8241,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -8529,6 +8606,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -10253,9 +10331,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -10277,9 +10352,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -10301,9 +10373,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -10325,9 +10394,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [

--- a/package.json
+++ b/package.json
@@ -15,9 +15,10 @@
   "dependencies": {
     "@cucumber/messages": "^32.2.0",
     "@cucumber/react-components": "^24.1.2",
+    "@hyperjump/browser": "^1.3.1",
+    "@hyperjump/json-schema": "^1.17.6",
     "@sentry/react": "^10.30.0",
     "@tanstack/react-query": "^5.85.6",
-    "ajv": "^8.18.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-error-boundary": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
     "typescript-eslint": "^8.39.1",
     "vite": "^8.0.0",
     "vitest": "^4.0.0",
-    "wrangler": "^4.85.0",
-    "zod": "^4.1.12"
+    "wrangler": "^4.85.0"
   }
 }

--- a/src/lib/validateEnvelopes.test.ts
+++ b/src/lib/validateEnvelopes.test.ts
@@ -13,8 +13,8 @@ describe('validateEnvelopes', () => {
     const invalidPaths = validateEnvelopes(lines)
 
     expect(invalidPaths).toEqual([
-      'gherkinDocument.feature.children.scenario.examples',
-      'testRunStarted.timestamp.nanos',
+      'gherkinDocument.feature.children.scenario',
+      'testRunStarted.timestamp',
     ])
   })
 })

--- a/src/lib/validateEnvelopes.ts
+++ b/src/lib/validateEnvelopes.ts
@@ -1,17 +1,18 @@
-import envelopeSchema from '@cucumber/messages/schema'
-import Ajv2020, { type ErrorObject } from 'ajv/dist/2020'
+import envelopeSchema from '@cucumber/messages/schema' with { type: 'json' }
+import { registerSchema, validate } from '@hyperjump/json-schema/draft-2020-12'
+import { BASIC } from '@hyperjump/json-schema/experimental'
 
-const ajv = new Ajv2020({ allErrors: true, strict: false })
-const validate = ajv.compile(envelopeSchema)
+registerSchema(envelopeSchema)
+const validator = await validate(envelopeSchema.$id)
 
 export function validateEnvelopes(envelopes: ReadonlyArray<string>): ReadonlyArray<string> {
   const invalidPaths = new Set<string>()
   for (const envelope of envelopes) {
     const parsed = JSON.parse(envelope)
-    const valid = validate(parsed)
-    if (!valid && validate.errors) {
-      for (const error of validate.errors) {
-        const path = makePath(error)
+    const output = validator(parsed, BASIC)
+    if (!output.valid && output.errors) {
+      for (const error of output.errors) {
+        const path = makePath(error.instanceLocation)
         if (path) {
           invalidPaths.add(path)
         }
@@ -21,15 +22,12 @@ export function validateEnvelopes(envelopes: ReadonlyArray<string>): ReadonlyArr
   return [...invalidPaths]
 }
 
-function makePath(error: ErrorObject): string {
-  let path = error.instancePath
-  // for "required" errors, append the missing property name
-  if (error.params?.missingProperty) {
-    path = `${path}/${error.params.missingProperty}`
-  }
-  return path
-    .replace(/^\//, '') // remove leading slash
-    .replace(/\/\d+\//g, '/') // remove array indexes like /0/
-    .replace(/\/\d+$/, '') // remove trailing array index
-    .replace(/\//g, '.') // replace slash separator with period
+function makePath(pointer: string): string {
+  return pointer
+    .replace(/^#/, '')
+    .replace(/^\//, '')
+    .split('/')
+    .filter((seg) => seg && !/^\d+$/.test(seg))
+    .map((seg) => seg.replace(/~1/g, '/').replace(/~0/g, '~'))
+    .join('.')
 }


### PR DESCRIPTION
### 🤔 What's changed?

Switch from `ajv` to the `@hyperjump` stack for our schema validation that feeds data quality telemetry.

### ⚡️ What's your motivation? 

- No more string evaluation of JavaScript in our app, so we can tighten the content security policy
- Consistent tooling for working with the schema between here and https://github.com/cucumber/messages (see https://github.com/cucumber/messages/pull/382)

### 🏷️ What kind of change is this?

- :bank: Refactoring/debt/DX (improvement to code design, tooling, etc. without changing behaviour)

### ♻️ Anything particular you want feedback on?

The error message is a bit lower fidelity - it gives the parent path, but not the key of the missing item - but this is easy to deduce anyway, and the alternative would have been to drill down into both the schema and the data each time which is just not worth it for this use case.

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
- [ ] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] Users should know about my change
  - [ ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
