### PR TITLE
Use reviver when validating

### DIFF
--- a/src/hooks/useEnvelopes.ts
+++ b/src/hooks/useEnvelopes.ts
@@ -1,6 +1,7 @@
 import { type Envelope, parseEnvelope } from '@cucumber/messages'
 import * as Sentry from '@sentry/react'
 import { useQuery } from '@tanstack/react-query'
+import { parseEnvelopeWithReviver } from '../lib/parseEnvelopeWithReviver.ts'
 import { validateEnvelopes } from '../lib/validateEnvelopes'
 
 export function useEnvelopes(id: string) {
@@ -35,7 +36,7 @@ export function emitTelemetry(envelopes: ReadonlyArray<string>, parsed: Readonly
       })
     }
 
-    const invalidPaths = validateEnvelopes(envelopes)
+    const invalidPaths = validateEnvelopes(envelopes, parseEnvelopeWithReviver)
     for (const path of invalidPaths) {
       Sentry.metrics.count('envelopes_validity', 1, { attributes: { path } })
     }

--- a/src/hooks/useEnvelopes.ts
+++ b/src/hooks/useEnvelopes.ts
@@ -1,7 +1,6 @@
 import { type Envelope, parseEnvelope } from '@cucumber/messages'
 import * as Sentry from '@sentry/react'
 import { useQuery } from '@tanstack/react-query'
-
 import { validateEnvelopes } from '../lib/validateEnvelopes'
 
 export function useEnvelopes(id: string) {

--- a/src/lib/parseEnvelopeWithReviver.test.ts
+++ b/src/lib/parseEnvelopeWithReviver.test.ts
@@ -1,0 +1,19 @@
+import type { Envelope } from '@cucumber/messages'
+import { describe, expect, it } from 'vitest'
+import { parseEnvelopeWithReviver } from './parseEnvelopeWithReviver'
+
+describe('parseEnvelopeWithReviver', () => {
+  it('defaults omitted fields in timestamps', () => {
+    const raw = `{"testRunStarted":{"id":"123","timestamp":{}}}`
+
+    expect(parseEnvelopeWithReviver(raw)).toEqual({
+      testRunStarted: {
+        id: '123',
+        timestamp: {
+          seconds: 0,
+          nanos: 0,
+        },
+      },
+    } satisfies Envelope)
+  })
+})

--- a/src/lib/parseEnvelopeWithReviver.ts
+++ b/src/lib/parseEnvelopeWithReviver.ts
@@ -1,0 +1,24 @@
+import type { Envelope } from '@cucumber/messages'
+
+export function parseEnvelopeWithReviver(raw: string): Envelope {
+  return JSON.parse(raw, (key, value) => {
+    if (typeof value === 'object') {
+      if ((key === 'timestamp' || key === 'duration') && typeof value.seconds !== 'number') {
+        value.seconds = 0
+      }
+      if ((key === 'timestamp' || key === 'duration') && typeof value.nanos !== 'number') {
+        value.nanos = 0
+      }
+      if (key === 'scenario' && !value.examples) {
+        value.examples = []
+      }
+      if (key === 'testCaseStarted' && typeof value.attempt !== 'number') {
+        value.attempt = 0
+      }
+      if (key === 'testCaseFinished' && typeof value.willBeRetried !== 'boolean') {
+        value.willBeRetried = false
+      }
+    }
+    return value
+  }) as Envelope
+}

--- a/src/lib/validateEnvelopes.ts
+++ b/src/lib/validateEnvelopes.ts
@@ -1,6 +1,7 @@
 import envelopeSchema from '@cucumber/messages/schema' with { type: 'json' }
 import { registerSchema, validate } from '@hyperjump/json-schema/draft-2020-12'
 import { BASIC } from '@hyperjump/json-schema/experimental'
+import { parseEnvelopeWithReviver } from './parseEnvelopeWithReviver.ts'
 
 registerSchema(envelopeSchema)
 const validator = await validate(envelopeSchema.$id)
@@ -8,7 +9,7 @@ const validator = await validate(envelopeSchema.$id)
 export function validateEnvelopes(envelopes: ReadonlyArray<string>): ReadonlyArray<string> {
   const invalidPaths = new Set<string>()
   for (const envelope of envelopes) {
-    const parsed = JSON.parse(envelope)
+    const parsed = parseEnvelopeWithReviver(envelope) as (typeof validator.arguments)[0]
     const output = validator(parsed, BASIC)
     if (!output.valid && output.errors) {
       for (const error of output.errors) {

--- a/src/lib/validateEnvelopes.ts
+++ b/src/lib/validateEnvelopes.ts
@@ -1,16 +1,19 @@
+import type { Envelope } from '@cucumber/messages'
 import envelopeSchema from '@cucumber/messages/schema' with { type: 'json' }
 import { registerSchema, validate } from '@hyperjump/json-schema/draft-2020-12'
 import { BASIC } from '@hyperjump/json-schema/experimental'
-import { parseEnvelopeWithReviver } from './parseEnvelopeWithReviver.ts'
 
 registerSchema(envelopeSchema)
 const validator = await validate(envelopeSchema.$id)
 
-export function validateEnvelopes(envelopes: ReadonlyArray<string>): ReadonlyArray<string> {
+export function validateEnvelopes(
+  lines: ReadonlyArray<string>,
+  parser: (raw: string) => Envelope = (raw) => JSON.parse(raw) as Envelope
+): ReadonlyArray<string> {
   const invalidPaths = new Set<string>()
-  for (const envelope of envelopes) {
-    const parsed = parseEnvelopeWithReviver(envelope) as (typeof validator.arguments)[0]
-    const output = validator(parsed, BASIC)
+  for (const raw of lines) {
+    const parsed = parser(raw)
+    const output = validator(parsed as (typeof validator.arguments)[0], BASIC)
     if (!output.valid && output.errors) {
       for (const error of output.errors) {
         const path = makePath(error.instanceLocation)

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -15,7 +15,7 @@ Sentry.init({
     Sentry.browserTracingIntegration(),
   ],
   enableLogs: true,
-  tracesSampleRate: 1.0,
+  tracesSampleRate: 0.1,
 })
 
 const queryClient = new QueryClient({


### PR DESCRIPTION
### 🤔 What's changed?

When validating each raw envelope for schema correctness, do the JSON parse with a reviver to add fallback values to missing fields.

### ⚡️ What's your motivation? 

With this mechanism in place for a handful of well-known omissions from older Cucumber versions, we can use our validation metrics to fill the remaining gaps so we'll no longer need the legacy `parseEnvelope` helper from the messages library which defaulted all fields but is gone from `33.0.0`.

### 🏷️ What kind of change is this?

- :bank: Refactoring/debt/DX (improvement to code design, tooling, etc. without changing behaviour)

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
- [x] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] Users should know about my change
  - [ ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
