### PR TITLE
Only report "required" validation errors

### DIFF
--- a/src/lib/validateEnvelopes.test.ts
+++ b/src/lib/validateEnvelopes.test.ts
@@ -17,4 +17,10 @@ describe('validateEnvelopes', () => {
       'testRunStarted.timestamp',
     ])
   })
+
+  it('ignores invalid paths for anything besides omissions', () => {
+    const invalidPaths = validateEnvelopes([`{"foo":"bar"}`])
+
+    expect(invalidPaths).toEqual([])
+  })
 })

--- a/src/lib/validateEnvelopes.ts
+++ b/src/lib/validateEnvelopes.ts
@@ -16,9 +16,11 @@ export function validateEnvelopes(
     const output = validator(parsed as (typeof validator.arguments)[0], BASIC)
     if (!output.valid && output.errors) {
       for (const error of output.errors) {
-        const path = makePath(error.instanceLocation)
-        if (path) {
-          invalidPaths.add(path)
+        if (error.keyword === 'https://json-schema.org/keyword/required') {
+          const path = makePath(error.instanceLocation)
+          if (path) {
+            invalidPaths.add(path)
+          }
         }
       }
     }


### PR DESCRIPTION
### 🤔 What's changed?

Only emit metrics for schema validation errors where they are for a missing required field.

### ⚡️ What's your motivation? 

There's some noise caused by other validation errors e.g. fields that have been removed from the schema but are harmlessly still included by older Cucumber versions.

### 🏷️ What kind of change is this?

- :bank: Refactoring/debt/DX (improvement to code design, tooling, etc. without changing behaviour)

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
- [ ] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] Users should know about my change
  - [ ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
