### PR TITLE
Handle more known messages omissions

### DIFF
--- a/src/lib/parseEnvelopeWithReviver.ts
+++ b/src/lib/parseEnvelopeWithReviver.ts
@@ -1,24 +1,93 @@
 import type { Envelope } from '@cucumber/messages'
 
-export function parseEnvelopeWithReviver(raw: string): Envelope {
-  return JSON.parse(raw, (key, value) => {
-    if (typeof value === 'object') {
-      if ((key === 'timestamp' || key === 'duration') && typeof value.seconds !== 'number') {
-        value.seconds = 0
-      }
-      if ((key === 'timestamp' || key === 'duration') && typeof value.nanos !== 'number') {
-        value.nanos = 0
-      }
-      if (key === 'scenario' && !value.examples) {
-        value.examples = []
-      }
-      if (key === 'testCaseStarted' && typeof value.attempt !== 'number') {
-        value.attempt = 0
-      }
-      if (key === 'testCaseFinished' && typeof value.willBeRetried !== 'boolean') {
-        value.willBeRetried = false
+type KnownOmission = {
+  key: string
+  type: 'string' | 'number' | 'boolean' | 'array'
+  fallback: unknown | (() => unknown)
+}
+
+const KNOWN_OMISSIONS: Record<string, ReadonlyArray<KnownOmission>> = {
+  background: [
+    { key: 'description', type: 'string', fallback: '' },
+    { key: 'steps', type: 'array', fallback: () => [] },
+  ],
+  cells: [{ key: 'value', type: 'string', fallback: '' }],
+  duration: [
+    { key: 'seconds', type: 'number', fallback: 0 },
+    { key: 'nanos', type: 'number', fallback: 0 },
+  ],
+  examples: [
+    { key: 'description', type: 'string', fallback: '' },
+    { key: 'name', type: 'string', fallback: '' },
+    { key: 'tags', type: 'array', fallback: () => [] },
+  ],
+  feature: [
+    { key: 'description', type: 'string', fallback: '' },
+    { key: 'tags', type: 'array', fallback: () => [] },
+  ],
+  javaMethod: [{ key: 'methodParameterTypes', type: 'array', fallback: () => [] }],
+  pattern: [{ key: 'type', type: 'string', fallback: 'CUCUMBER_EXPRESSION' }],
+  rule: [
+    { key: 'description', type: 'string', fallback: '' },
+    { key: 'tags', type: 'array', fallback: () => [] },
+  ],
+  scenario: [
+    { key: 'description', type: 'string', fallback: '' },
+    {
+      key: 'tags',
+      type: 'array',
+      fallback: () => [],
+    },
+    {
+      key: 'examples',
+      type: 'array',
+      fallback: () => [],
+    },
+  ],
+  stepMatchArgumentsLists: [
+    {
+      key: 'stepMatchArguments',
+      type: 'array',
+      fallback: () => [],
+    },
+  ],
+  testCaseFinished: [{ key: 'willBeRetried', type: 'boolean', fallback: false }],
+  testCaseStarted: [{ key: 'attempt', type: 'number', fallback: 0 }],
+  timestamp: [
+    { key: 'seconds', type: 'number', fallback: 0 },
+    { key: 'nanos', type: 'number', fallback: 0 },
+  ],
+}
+
+function matchesType(type: KnownOmission['type'], value: unknown): boolean {
+  return type === 'array' ? Array.isArray(value) : typeof value === type
+}
+
+// biome-ignore lint/suspicious/noExplicitAny: reviver must handle any value
+function isPlainObject(value: any) {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+// biome-ignore lint/suspicious/noExplicitAny: reviver must handle any value
+function reviver(key: string, value: any) {
+  if (isPlainObject(value)) {
+    // check known omissions within this object and apply fallbacks
+    for (const omission of KNOWN_OMISSIONS[key] ?? []) {
+      if (!matchesType(omission.type, value[omission.key])) {
+        value[omission.key] =
+          typeof omission.fallback === 'function' ? omission.fallback() : omission.fallback
       }
     }
-    return value
-  }) as Envelope
+    // do the same logic for items in arrays
+    for (const [childKey, childValue] of Object.entries(value)) {
+      if (Array.isArray(childValue)) {
+        value[childKey] = childValue.map((childItem) => reviver(childKey, childItem))
+      }
+    }
+  }
+  return value
+}
+
+export function parseEnvelopeWithReviver(raw: string): Envelope {
+  return JSON.parse(raw, reviver) as Envelope
 }


### PR DESCRIPTION
### 🤔 What's changed?

Following https://github.com/cucumber/cucumber-reports/pull/113, add fallbacks for more known omissions based on telemetry.

### 🏷️ What kind of change is this?

- :bank: Refactoring/debt/DX (improvement to code design, tooling, etc. without changing behaviour)

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
- [ ] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] Users should know about my change
  - [ ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
