### PR TITLE
Handle more known messages omissions again

### DIFF
--- a/src/lib/parseEnvelopeWithReviver.ts
+++ b/src/lib/parseEnvelopeWithReviver.ts
@@ -7,8 +7,10 @@ type KnownOmission = {
 }
 
 const KNOWN_OMISSIONS: Record<string, ReadonlyArray<KnownOmission>> = {
+  attachment: [{ key: 'contentEncoding', type: 'string', fallback: 'IDENTITY' }],
   background: [
     { key: 'description', type: 'string', fallback: '' },
+    { key: 'name', type: 'string', fallback: '' },
     { key: 'steps', type: 'array', fallback: () => [] },
   ],
   cells: [{ key: 'value', type: 'string', fallback: '' }],
@@ -23,16 +25,33 @@ const KNOWN_OMISSIONS: Record<string, ReadonlyArray<KnownOmission>> = {
   ],
   feature: [
     { key: 'description', type: 'string', fallback: '' },
+    { key: 'name', type: 'string', fallback: '' },
     { key: 'tags', type: 'array', fallback: () => [] },
+  ],
+  gherkinDocument: [
+    {
+      key: 'comments',
+      type: 'array',
+      fallback: () => [],
+    },
   ],
   javaMethod: [{ key: 'methodParameterTypes', type: 'array', fallback: () => [] }],
   pattern: [{ key: 'type', type: 'string', fallback: 'CUCUMBER_EXPRESSION' }],
+  pickle: [
+    {
+      key: 'tags',
+      type: 'array',
+      fallback: () => [],
+    },
+  ],
   rule: [
     { key: 'description', type: 'string', fallback: '' },
+    { key: 'name', type: 'string', fallback: '' },
     { key: 'tags', type: 'array', fallback: () => [] },
   ],
   scenario: [
     { key: 'description', type: 'string', fallback: '' },
+    { key: 'name', type: 'string', fallback: '' },
     {
       key: 'tags',
       type: 'array',


### PR DESCRIPTION
### 🤔 What's changed?

Based on telemetry, add more fallbacks for fields omitted by older versions of Cucumber in the wild.

### 🏷️ What kind of change is this?

- :bank: Refactoring/debt/DX (improvement to code design, tooling, etc. without changing behaviour)

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
- [ ] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] Users should know about my change
  - [ ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
