### PR TITLE
Generate Cloudflare worker types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,10 @@
 # See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
 
+# Generated worker types
+worker-configuration.d.ts
+
 # wrangler local development state
-.wrangler
+/.wrangler
 
 # dependencies
 /node_modules
@@ -39,3 +42,6 @@ yarn-error.log*
 
 # typescript
 *.tsbuildinfo
+
+# InteliJ IDEA
+/.idea

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,6 @@
       "devDependencies": {
         "@biomejs/biome": "^2.4.14",
         "@cloudflare/vite-plugin": "^1.42.1",
-        "@cloudflare/workers-types": "^5.0.0",
         "@cucumber/biome-config": "github:cucumber/biome-config#v0.6.0",
         "@cucumber/node": "^0.7.0",
         "@tailwindcss/postcss": "^4.1.12",
@@ -432,42 +431,6 @@
         "wrangler": "^4.118.0"
       }
     },
-    "node_modules/@cloudflare/vite-plugin/node_modules/wrangler": {
-      "version": "4.116.0",
-      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.116.0.tgz",
-      "integrity": "sha512-wP1PXxH5KJajfGEjty0NNqyxAirTFvMZpGyB5CRqEIiY0fL/SiCKtIYAJB9HXq0MP0sMXB/i/YSls+WObahAhw==",
-      "dev": true,
-      "license": "MIT OR Apache-2.0",
-      "dependencies": {
-        "@cloudflare/kv-asset-handler": "0.5.0",
-        "@cloudflare/unenv-preset": "2.16.1",
-        "blake3-wasm": "2.1.5",
-        "esbuild": "0.28.1",
-        "miniflare": "4.20260730.0",
-        "path-to-regexp": "6.3.0",
-        "unenv": "2.0.0-rc.24",
-        "workerd": "1.20260730.1"
-      },
-      "bin": {
-        "cf-wrangler": "bin/cf-wrangler.js",
-        "wrangler": "bin/wrangler.js",
-        "wrangler2": "bin/wrangler.js"
-      },
-      "engines": {
-        "node": ">=22.0.0"
-      },
-      "optionalDependencies": {
-        "fsevents": "2.3.3"
-      },
-      "peerDependencies": {
-        "@cloudflare/workers-types": "^5.20260730.1"
-      },
-      "peerDependenciesMeta": {
-        "@cloudflare/workers-types": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@cloudflare/workerd-darwin-64": {
       "version": "1.20260730.1",
       "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260730.1.tgz",
@@ -552,13 +515,6 @@
       "engines": {
         "node": ">=16"
       }
-    },
-    "node_modules/@cloudflare/workers-types": {
-      "version": "5.20260731.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-5.20260731.1.tgz",
-      "integrity": "sha512-ly+eua642FCR2nbQGi/OxqlVaJI3fNdyqK7G4u6jWCAZ4WYhOBvZWyf0M7s5zurWbNQW3YjelOxuKqR0zYK90w==",
-      "dev": true,
-      "license": "MIT OR Apache-2.0"
     },
     "node_modules/@cspotcode/source-map-support": {
       "version": "0.8.1",
@@ -9030,24 +8986,6 @@
         "@cloudflare/workers-types": {
           "optional": true
         }
-      }
-    },
-    "node_modules/wrangler/node_modules/miniflare": {
-      "version": "5.20260730.0-alpha",
-      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-5.20260730.0-alpha.tgz",
-      "integrity": "sha512-8/dspSXDshP6nSkCpjKO7BYc2qZoYSXm7iM+QxY7qJyJpAB3onnQSaiu0cvKJlfuMGwULl55hG69FJCcCMXU1Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@cspotcode/source-map-support": "0.8.1",
-        "sharp": "0.35.2",
-        "undici": "7.28.0",
-        "workerd": "1.20260730.1",
-        "ws": "8.21.0",
-        "youch": "4.1.0-beta.10"
-      },
-      "engines": {
-        "node": ">=22.0.0"
       }
     },
     "node_modules/wrap-ansi": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "private": true,
   "scripts": {
     "dev": "vite",
-    "build": "tsc -b && vite build",
+    "build": "npm run generate-types && tsc -b && vite build",
+    "generate-types": "wrangler types",
     "fix": "biome check --fix --error-on-warnings",
     "lint": "biome check --error-on-warnings",
     "preview": "vite preview",
@@ -29,7 +30,6 @@
   "devDependencies": {
     "@biomejs/biome": "^2.4.14",
     "@cloudflare/vite-plugin": "^1.42.1",
-    "@cloudflare/workers-types": "^5.0.0",
     "@cucumber/biome-config": "github:cucumber/biome-config#v0.6.0",
     "@cucumber/node": "^0.7.0",
     "@tailwindcss/postcss": "^4.1.12",

--- a/tsconfig.worker.json
+++ b/tsconfig.worker.json
@@ -5,7 +5,7 @@
     "module": "ESNext",
     "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,
-    "types": ["@cloudflare/workers-types", "node"],
+    "types": ["./worker-configuration", "node"],
     "strict": true,
     "skipLibCheck": true,
     "noEmit": true,

--- a/worker/env.ts
+++ b/worker/env.ts
@@ -1,7 +1,0 @@
-export interface Env {
-  ASSETS: Fetcher
-  REPORTS_BUCKET: R2Bucket
-  BASE_URL: string
-  SIGNING_KEY: string
-  UPLOAD_TTL: string
-}

--- a/worker/handleDelete.ts
+++ b/worker/handleDelete.ts
@@ -1,5 +1,3 @@
-import type { Env } from './env.ts'
-
 export async function handleDelete(env: Env, id: string): Promise<Response> {
   await env.REPORTS_BUCKET.delete(id)
   return new Response(undefined, { status: 200 })

--- a/worker/handleFetch.ts
+++ b/worker/handleFetch.ts
@@ -1,6 +1,3 @@
-import type { R2ObjectBody } from '@cloudflare/workers-types'
-
-import type { Env } from './env.ts'
 import { writeResponse } from './writeResponse.ts'
 
 export async function handleFetch(env: Env, id: string): Promise<Response> {

--- a/worker/handleTouch.ts
+++ b/worker/handleTouch.ts
@@ -1,5 +1,4 @@
 import { makeReportBanner, tokenBanner } from './banner'
-import type { Env } from './env.ts'
 import { sign } from './signing'
 import { writeResponse } from './writeResponse.ts'
 

--- a/worker/handleUpload.ts
+++ b/worker/handleUpload.ts
@@ -1,4 +1,3 @@
-import type { Env } from './env.ts'
 import { verify } from './signing'
 import { writeResponse } from './writeResponse.ts'
 

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -1,4 +1,3 @@
-import type { Env } from './env.ts'
 import { handleDelete } from './handleDelete.ts'
 import { handleFetch } from './handleFetch.ts'
 import { handleTouch } from './handleTouch.ts'


### PR DESCRIPTION
### ⚡️ What's your motivation? 

`@cloudflare/workers-types` is versioned by compatibility date. This results in a new version every day. To avoid Renovate updating `@cloudflare/workers-types` in `package-lock.json` every day, the recommendation is to generate the types using `npx wrangler types`.

See: https://developers.cloudflare.com/workers/languages/typescript

### 🏷️ What kind of change is this?

- :bank: Refactoring/debt/DX (improvement to code design, tooling, etc. without changing behaviour)

### 📋 Checklist:
- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
