### PR TITLE
Add fallbacks for child arrays in GherkinDocument tree

### DIFF
--- a/src/lib/parseEnvelopeWithReviver.ts
+++ b/src/lib/parseEnvelopeWithReviver.ts
@@ -24,6 +24,7 @@ const KNOWN_OMISSIONS: Record<string, ReadonlyArray<KnownOmission>> = {
     { key: 'tags', type: 'array', fallback: () => [] },
   ],
   feature: [
+    { key: 'children', type: 'array', fallback: () => [] },
     { key: 'description', type: 'string', fallback: '' },
     { key: 'name', type: 'string', fallback: '' },
     { key: 'tags', type: 'array', fallback: () => [] },
@@ -45,6 +46,7 @@ const KNOWN_OMISSIONS: Record<string, ReadonlyArray<KnownOmission>> = {
     },
   ],
   rule: [
+    { key: 'children', type: 'array', fallback: () => [] },
     { key: 'description', type: 'string', fallback: '' },
     { key: 'name', type: 'string', fallback: '' },
     { key: 'tags', type: 'array', fallback: () => [] },

--- a/src/lib/parseEnvelopeWithReviver.ts
+++ b/src/lib/parseEnvelopeWithReviver.ts
@@ -21,6 +21,11 @@ const KNOWN_OMISSIONS: Record<string, ReadonlyArray<KnownOmission>> = {
   examples: [
     { key: 'description', type: 'string', fallback: '' },
     { key: 'name', type: 'string', fallback: '' },
+    {
+      key: 'tableBody',
+      type: 'array',
+      fallback: () => [],
+    },
     { key: 'tags', type: 'array', fallback: () => [] },
   ],
   feature: [
@@ -53,14 +58,14 @@ const KNOWN_OMISSIONS: Record<string, ReadonlyArray<KnownOmission>> = {
   ],
   scenario: [
     { key: 'description', type: 'string', fallback: '' },
-    { key: 'name', type: 'string', fallback: '' },
     {
-      key: 'tags',
+      key: 'examples',
       type: 'array',
       fallback: () => [],
     },
+    { key: 'name', type: 'string', fallback: '' },
     {
-      key: 'examples',
+      key: 'tags',
       type: 'array',
       fallback: () => [],
     },


### PR DESCRIPTION
### 🤔 What's changed?

Based on errors observed with data from cucumber-jvm 6.11.0, add empty-array fallbacks for `Feature.children` and `Rule.children`, plus `Scenario.examples` and `Examples.tableBody`.

### 🏷️ What kind of change is this?

- :bug: Bug fix (non-breaking change which fixes a defect)

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
- [x] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] Users should know about my change
  - [ ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
